### PR TITLE
Update calendar-phat.py

### DIFF
--- a/examples/phat/calendar-phat.py
+++ b/examples/phat/calendar-phat.py
@@ -29,7 +29,10 @@ colour = args.colour
 
 inky_display = InkyPHAT(colour)
 inky_display.set_border(inky_display.BLACK)
-# inky_display.set_rotation(180)
+
+#uncomment the following if you want to flip it 180 degrees
+#inky_display.h_flip = True
+#inky_display.v_flip = True
 
 
 def create_mask(source, mask=(inky_display.WHITE, inky_display.BLACK, inky_display.RED)):


### PR DESCRIPTION
The commented code was misleading. I think that the set_rotation was from the previous library(?). On this new one, the way that I found to rotate it 180 degrees (use the pi upside down) was through the flips.