### PR TITLE
Fix EPDType.encode str vs bytes conflict

### DIFF
--- a/library/inky/eeprom.py
+++ b/library/inky/eeprom.py
@@ -58,7 +58,7 @@ Time: {}""".format(self.width,
                            self.color,
                            self.pcb_variant,
                            self.display_variant,
-                           str(datetime.datetime.now()))
+                           str(datetime.datetime.now()).encode("ASCII"))
 
     def to_list(self):
         """Return a list of bytes representing the EEPROM data structure."""


### PR DESCRIPTION
Issue: EPDType.encode tried to pack a str into a 22p struct format. However, in
Python 3 onward, 22p will only accept a bytes.

Resolution: Encode the string using the ASCII charset. This guarantees that
only one byte is used per character. Non-ASCII characters will never be
generated.