### PR TITLE
Try auto-detection first and only fall back to parsing args

### DIFF
--- a/examples/clean.py
+++ b/examples/clean.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import time
 import argparse
-from inky import InkyPHAT, InkyWHAT
+import time
+
+from inky.auto import auto
 from PIL import Image
 
 print("""Inky pHAT: Clean
@@ -13,22 +14,12 @@ display of any ghosting.
 
 """)
 
-# Command line arguments to set display type and colour, and number of cycles to run
+inky_display = auto(ask_user=True, verbose=True)
 
+# Command line arguments to determine number of cycles to run
 parser = argparse.ArgumentParser()
-parser.add_argument('--type', '-t', type=str, required=True, choices=["what", "phat"], help="type of display")
-parser.add_argument('--colour', '-c', type=str, required=True, choices=["red", "black", "yellow"], help="ePaper display colour")
 parser.add_argument('--number', '-n', type=int, required=False, help="number of cycles")
 args = parser.parse_args()
-
-colour = args.colour
-
-# Set up the correct display and scaling factors
-
-if args.type == "phat":
-    inky_display = InkyPHAT(colour)
-elif args.type == "what":
-    inky_display = InkyWHAT(colour)
 
 # The number of red / black / white refreshes to run
 
@@ -38,7 +29,7 @@ else:
     cycles = 3
 
 colours = (inky_display.RED, inky_display.BLACK, inky_display.WHITE)
-colour_names = (colour, "black", "white")
+colour_names = (inky_display.colour, "black", "white")
 
 # Create a new canvas to draw on
 

--- a/examples/identify.py
+++ b/examples/identify.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+from inky.eeprom import read_eeprom
+
+display = read_eeprom()
+
+if display is None:
+    print("""
+No display EEPROM detected,
+you might have an old Inky board that doesn't have an EEPROM - eg: early Inky pHAT boards.
+
+Try running examples with --colour <black/red/yellow>
+
+Or writing your code using:
+
+from inky.phat import InkyPHAT
+
+display = InkyPHAT("<black/red/yellow>")
+
+""")
+else:
+    print("Found: {}".format(display.get_variant()))
+    print(display)

--- a/examples/logo.py
+++ b/examples/logo.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 
 import os
-import argparse
 from PIL import Image
 from inky.auto import auto
-from inky import InkyWHAT, InkyPHAT, InkyPHAT_SSD1608
 
 
 print("""Inky pHAT/wHAT: Logo

--- a/examples/logo.py
+++ b/examples/logo.py
@@ -3,6 +3,8 @@
 import os
 import argparse
 from PIL import Image
+from inky.auto import auto
+from inky import InkyWHAT, InkyPHAT, InkyPHAT_SSD1608
 
 
 print("""Inky pHAT/wHAT: Logo
@@ -15,70 +17,53 @@ Displays the Inky pHAT/wHAT logo.
 
 PATH = os.path.dirname(__file__)
 
-# Command line arguments to set display type and colour
-
-parser = argparse.ArgumentParser()
-parser.add_argument('--mock', '-m', required=False, action='store_true', help="Simulate Inky using MatPlotLib")
-parser.add_argument('--type', '-t', type=str, required=False, default="auto", choices=["auto", "what", "phat", "phatssd1608"], help="type of display")
-parser.add_argument('--colour', '-c', type=str, required=False, choices=["red", "black", "yellow"], help="ePaper display colour")
-args = parser.parse_args()
-
-if args.mock:
-    from inky import InkyMockPHAT as InkyPHAT
-    from inky import InkyMockWHAT as InkyWHAT
-else:
-    from inky import InkyWHAT, InkyPHAT, InkyPHAT_SSD1608
-
-colour = args.colour
-
-# Set up the correct display and scaling factors
-
-if args.type == "phat":
-    inky_display = InkyPHAT(colour)
-elif args.type == "phatssd1608":
-    inky_display = InkyPHAT_SSD1608(colour)
-elif args.type == "what":
-    inky_display = InkyWHAT(colour)
-elif args.type == "auto":
-    from inky.auto import auto
+# Try to auto-detect the display from the EEPROM
+try:
     inky_display = auto()
-    resolution = inky_display.resolution
-    colour = inky_display.colour
-    if resolution == (212, 104):
-        args.type = "phat"
-    if resolution == (250, 122):
-        args.type = "phatssd1608"
-    if resolution == (400, 300):
-        args.type = "what"
+    print("Auto-detected {}".format(inky_display.eeprom.get_variant()))
+except RuntimeError:
+    inky_display = None
 
+# Parse the command-line and try manual display setup
+if inky_display is None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--type', '-t', type=str, required=False, default="auto", choices=["auto", "what", "phat", "phatssd1608"], help="type of display")
+    parser.add_argument('--colour', '-c', type=str, required=False, choices=["red", "black", "yellow"], help="ePaper display colour")
+    args = parser.parse_args()
+
+    if args.type == "phat":
+        inky_display = InkyPHAT(colour)
+    elif args.type == "phatssd1608":
+        inky_display = InkyPHAT_SSD1608(colour)
+    elif args.type == "what":
+        inky_display = InkyWHAT(colour)
+    elif args.type == "auto":
+        raise RuntimeError("Failed to auto-detect your Inky board type.")
 
 inky_display.set_border(inky_display.BLACK)
 
-# Pick the correct logo image to show depending on display type/colour
+# Pick the correct logo image to show depending on display resolution/colour
 
-if args.type == "phat" or args.type == "phatssd1608":
-    if args.type == "phatssd1608":
-        if colour == 'black':
+if inky_display.resolution in ((212, 104), (250, 122)):
+    if inky_display.resolution == (250, 122):
+        if inky_display.colour == 'black':
             img = Image.open(os.path.join(PATH, "phat/resources/InkypHAT-250x122-bw.png"))
         else:
             img = Image.open(os.path.join(PATH, "phat/resources/InkypHAT-250x122.png"))
 
     else:
-        if colour == 'black':
+        if inky_display.colour == 'black':
             img = Image.open(os.path.join(PATH, "phat/resources/InkypHAT-212x104-bw.png"))
         else:
             img = Image.open(os.path.join(PATH, "phat/resources/InkypHAT-212x104.png"))
 
-elif args.type == "what":
-    if colour == 'black':
+elif inky_display.resolution in ((400, 300)):
+    if inky_display.colour == 'black':
         img = Image.open(os.path.join(PATH, "what/resources/InkywHAT-400x300-bw.png"))
     else:
         img = Image.open(os.path.join(PATH, "what/resources/InkywHAT-400x300.png"))
 
 # Display the logo image
+
 inky_display.set_image(img)
 inky_display.show()
-
-if args.mock:
-    print("Press Ctrl+C or close window to exit...")
-    inky_display.wait_for_window_close()

--- a/examples/logo.py
+++ b/examples/logo.py
@@ -15,7 +15,11 @@ Displays the Inky pHAT/wHAT logo.
 PATH = os.path.dirname(__file__)
 
 # Set up the Inky display
-inky_display = auto(ask_user=True, verbose=True)
+try:
+    inky_display = auto(ask_user=True, verbose=True)
+except TypeError:
+    raise TypeError("You need to update the Inky library to >= v1.1.0")
+
 inky_display.set_border(inky_display.BLACK)
 
 # Pick the correct logo image to show depending on display resolution/colour

--- a/examples/logo.py
+++ b/examples/logo.py
@@ -14,32 +14,10 @@ Displays the Inky pHAT/wHAT logo.
 """)
 
 # Get the current path
-
 PATH = os.path.dirname(__file__)
 
-# Try to auto-detect the display from the EEPROM
-try:
-    inky_display = auto()
-    print("Auto-detected {}".format(inky_display.eeprom.get_variant()))
-except RuntimeError:
-    inky_display = None
-
-# Parse the command-line and try manual display setup
-if inky_display is None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--type', '-t', type=str, required=False, default="auto", choices=["auto", "what", "phat", "phatssd1608"], help="type of display")
-    parser.add_argument('--colour', '-c', type=str, required=False, choices=["red", "black", "yellow"], help="ePaper display colour")
-    args = parser.parse_args()
-
-    if args.type == "phat":
-        inky_display = InkyPHAT(colour)
-    elif args.type == "phatssd1608":
-        inky_display = InkyPHAT_SSD1608(colour)
-    elif args.type == "what":
-        inky_display = InkyWHAT(colour)
-    elif args.type == "auto":
-        raise RuntimeError("Failed to auto-detect your Inky board type.")
-
+# Set up the Inky display
+inky_display = auto(ask_user=True, verbose=True)
 inky_display.set_border(inky_display.BLACK)
 
 # Pick the correct logo image to show depending on display resolution/colour

--- a/examples/name-badge.py
+++ b/examples/name-badge.py
@@ -15,29 +15,8 @@ Use Inky pHAT/wHAT as a personalised name badge!
 
 """)
 
-# Try to auto-detect the display from the EEPROM
-try:
-    from inky.auto import auto
-    inky_display = auto()
-    print("Auto-detected {}".format(inky_display.eeprom.get_variant()))
-except RuntimeError:
-    inky_display = None
-
-# Parse the command-line and try manual display setup
-if inky_display is None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--type', '-t', type=str, required=True, default="auto", choices=["auto", "what", "phat", "phatssd1608"], help="type of display")
-    parser.add_argument('--colour', '-c', type=str, required=True, choices=["red", "black", "yellow"], help="ePaper display colour")
-    args = parser.parse_known_args()
-
-    if args.type == "phat":
-        inky_display = InkyPHAT(colour)
-    elif args.type == "phatssd1608":
-        inky_display = InkyPHAT_SSD1608(colour)
-    elif args.type == "what":
-        inky_display = InkyWHAT(colour)
-    elif args.type == "auto":
-        raise RuntimeError("Failed to auto-detect your Inky board type.")
+from inky.auto import auto
+inky_display = auto(ask_user=True, verbose=True)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--name', '-n', type=str, required=True, help="Your name")

--- a/examples/name-badge.py
+++ b/examples/name-badge.py
@@ -14,7 +14,10 @@ Use Inky pHAT/wHAT as a personalised name badge!
 
 """)
 
-inky_display = auto(ask_user=True, verbose=True)
+try:
+    inky_display = auto(ask_user=True, verbose=True)
+except TypeError:
+    raise TypeError("You need to update the Inky library to >= v1.1.0")
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--name', '-n', type=str, required=True, help="Your name")

--- a/examples/name-badge.py
+++ b/examples/name-badge.py
@@ -6,7 +6,6 @@ from PIL import Image, ImageFont, ImageDraw
 from font_hanken_grotesk import HankenGroteskBold, HankenGroteskMedium
 from font_intuitive import Intuitive
 from inky.auto import auto
-from inky import InkyWHAT, InkyPHAT, InkyPHAT_SSD1608
 
 
 print("""Inky pHAT/wHAT: Hello... my name is:
@@ -15,7 +14,6 @@ Use Inky pHAT/wHAT as a personalised name badge!
 
 """)
 
-from inky.auto import auto
 inky_display = auto(ask_user=True, verbose=True)
 
 parser = argparse.ArgumentParser()

--- a/examples/phat/calendar-phat.py
+++ b/examples/phat/calendar-phat.py
@@ -40,6 +40,7 @@ except RuntimeError:
     if colour == "auto":
         raise RuntimeError("Failed to auto-detect your Inky pHAT, try specifying a colour manually.")
     else:
+        print("No EEPROM detected, assuming Inky pHAT")
         inky_display = InkyPHAT(colour)
 
 inky_display.set_border(inky_display.BLACK)

--- a/examples/phat/calendar-phat.py
+++ b/examples/phat/calendar-phat.py
@@ -21,7 +21,11 @@ composited over the background in a couple of different ways.
 PATH = os.path.dirname(__file__)
 
 # Set up the display
-inky_display = auto(ask_user=True, verbose=True)
+try:
+    inky_display = auto(ask_user=True, verbose=True)
+except TypeError:
+    raise TypeError("You need to update the Inky library to >= v1.1.0")
+
 
 if inky_display.resolution not in ((212, 104), (250, 122)):
     w, h = inky_display.resolution

--- a/examples/phat/calendar-phat.py
+++ b/examples/phat/calendar-phat.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
-import datetime
 import calendar
-import argparse
+import datetime
+import os
 
+from inky.auto import auto
 from PIL import Image, ImageDraw
-
-from inky import InkyPHAT
 
 print("""Inky pHAT: Calendar
 
@@ -22,26 +20,12 @@ composited over the background in a couple of different ways.
 
 PATH = os.path.dirname(__file__)
 
-# Command line arguments to set display type and colour
-
-parser = argparse.ArgumentParser()
-parser.add_argument('--colour', '-c', type=str, required=False, default="auto", choices=["auto", "red", "black", "yellow"], help="ePaper display colour")
-args = parser.parse_args()
-
-colour = args.colour
-
 # Set up the display
-try:
-    from inky.auto import auto
-    inky_display = auto()
-    colour = inky_display.colour
-    print("Auto-detected {} Inky pHAT".format(colour))
-except RuntimeError:
-    if colour == "auto":
-        raise RuntimeError("Failed to auto-detect your Inky pHAT, try specifying a colour manually.")
-    else:
-        print("No EEPROM detected, assuming Inky pHAT")
-        inky_display = InkyPHAT(colour)
+inky_display = auto(ask_user=True, verbose=True)
+
+if inky_display.resolution not in ((212, 104), (250, 122)):
+    w, h = inky_display.resolution
+    raise RuntimeError("This example does not support {}x{}".format(w, h))
 
 inky_display.set_border(inky_display.BLACK)
 

--- a/examples/phat/weather-phat.py
+++ b/examples/phat/weather-phat.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 
 import glob
-import time
-import argparse
 import os
+import time
 from sys import exit
-from inky import InkyPHAT
-from PIL import Image, ImageDraw, ImageFont
+
 from font_fredoka_one import FredokaOne
+from inky.auto import auto
+from PIL import Image, ImageDraw, ImageFont
 
 """
 To run this example on Python 2.x you should:
@@ -43,27 +43,14 @@ Displays weather information for a given location. The default location is Sheff
 """)
 
 # Get the current path
-
 PATH = os.path.dirname(__file__)
 
-# Command line arguments to set display colour
-
-parser = argparse.ArgumentParser()
-parser.add_argument('--colour', '-c', type=str, required=False, default="auto", choices=["auto", "red", "black", "yellow"], help="ePaper display colour")
-args = parser.parse_args()
-
 # Set up the display
-try:
-    from inky.auto import auto
-    inky_display = auto()
-    colour = inky_display.colour
-    print("Auto-detected {} Inky pHAT".format(colour))
-except RuntimeError:
-    if colour == "auto":
-        raise RuntimeError("Failed to auto-detect your Inky pHAT, try specifying a colour manually.")
-    else:
-        print("No EEPROM detected, assuming Inky pHAT")
-        inky_display = InkyPHAT(colour)
+inky_display = auto(ask_user=True, verbose=True)
+
+if inky_display.resolution not in ((212, 104), (250, 122)):
+    w, h = inky_display.resolution
+    raise RuntimeError("This example does not support {}x{}".format(w, h))
 
 inky_display.set_border(inky_display.BLACK)
 

--- a/examples/phat/weather-phat.py
+++ b/examples/phat/weather-phat.py
@@ -62,6 +62,7 @@ except RuntimeError:
     if colour == "auto":
         raise RuntimeError("Failed to auto-detect your Inky pHAT, try specifying a colour manually.")
     else:
+        print("No EEPROM detected, assuming Inky pHAT")
         inky_display = InkyPHAT(colour)
 
 inky_display.set_border(inky_display.BLACK)

--- a/examples/phat/weather-phat.py
+++ b/examples/phat/weather-phat.py
@@ -46,7 +46,10 @@ Displays weather information for a given location. The default location is Sheff
 PATH = os.path.dirname(__file__)
 
 # Set up the display
-inky_display = auto(ask_user=True, verbose=True)
+try:
+    inky_display = auto(ask_user=True, verbose=True)
+except TypeError:
+    raise TypeError("You need to update the Inky library to >= v1.1.0")
 
 if inky_display.resolution not in ((212, 104), (250, 122)):
     w, h = inky_display.resolution

--- a/library/inky/auto.py
+++ b/library/inky/auto.py
@@ -1,13 +1,26 @@
 from .phat import InkyPHAT, InkyPHAT_SSD1608  # noqa: F401
 from .what import InkyWHAT                    # noqa: F401
 from . import eeprom
+import argparse
 
 
-def auto(i2c_bus=None):
+def auto(i2c_bus=None, ask_user=False, verbose=False):
     _eeprom = eeprom.read_eeprom(i2c_bus=i2c_bus)
 
     if _eeprom is None:
-        raise RuntimeError("No EEPROM detected! You must manually initialise your Inky board.")
+        if fallback:
+            parser = argparse.ArgumentParser()
+            parser.add_argument('--type', '-t', type=str, required=True, choices=["what", "phat", "phatssd1608"], help="Type of display")
+            parser.add_argument('--colour', '-c', type=str, required=False, choices=["red", "black", "yellow"], help="Display colour")
+            args = parser.parse_known_args()
+            if args.type == "phat":
+                return InkyPHAT(args.colour)
+            if args.type == "phatssd1608":
+                return InkyPHAT_SSD1608(args.colour)
+            if args.type == "what":
+                return InkyWHAT(args.colour)
+        else:
+            raise RuntimeError("No EEPROM detected! You must manually initialise your Inky board.")
 
     """
     The EEPROM is used to disambiguate the variants of wHAT and pHAT
@@ -23,6 +36,9 @@ def auto(i2c_bus=None):
     11  Red pHAT (ssd1608)
     12  Yellow pHAT (ssd1608)
     """
+
+    if verbose:
+        print("Detected {}".format(_eeprom.get_variant()))
 
     if _eeprom.display_variant in (1, 4, 5):
         return InkyPHAT(_eeprom.get_color())

--- a/library/inky/auto.py
+++ b/library/inky/auto.py
@@ -8,7 +8,10 @@ def auto(i2c_bus=None, ask_user=False, verbose=False):
     _eeprom = eeprom.read_eeprom(i2c_bus=i2c_bus)
 
     if _eeprom is None:
-        if fallback:
+        if ask_user:
+            if verbose:
+                print("""Failed to detect an Inky board, you must specify the type and colour manually.
+""")
             parser = argparse.ArgumentParser()
             parser.add_argument('--type', '-t', type=str, required=True, choices=["what", "phat", "phatssd1608"], help="Type of display")
             parser.add_argument('--colour', '-c', type=str, required=False, choices=["red", "black", "yellow"], help="Display colour")

--- a/library/inky/eeprom.py
+++ b/library/inky/eeprom.py
@@ -10,6 +10,35 @@ EEP_ADRESS = 0x50
 EEP_WP = 12
 
 
+# The EEPROM is used to disambiguate the variants of wHAT and pHAT
+# 1   Red pHAT (High-Temp)
+# 2   Yellow wHAT (1_E)
+# 3   Black wHAT (1_E)
+# 4   Black pHAT (Normal)
+# 5   Yellow pHAT (DEP0213YNS75AFICP)
+# 6   Red wHAT (Regular)
+# 7   Red wHAT (High-Temp)
+# 8   Red wHAT (DEPG0420RWS19AF0HP)
+# 10  BW pHAT (ssd1608) (DEPG0213BNS800F13CP)
+# 11  Red pHAT (ssd1608)
+# 12  Yellow pHAT (ssd1608)
+DISPLAY_VARIANT = [
+    None,
+    'Red pHAT (High-Temp)',
+    'Yellow wHAT',
+    'Black wHAT',
+    'Black pHAT',
+    'Yellow pHAT',
+    'Red wHAT',
+    'Red wHAT (High-Temp)',
+    'Red wHAT',
+    None,
+    'Black pHAT (SSD1608)',
+    'Red pHAT (SSD1608)',
+    'Yellow pHAT (SSD1608)'
+]
+
+
 class EPDType:
     """Class to represent EPD EEPROM structure."""
 
@@ -75,6 +104,12 @@ Time: {}""".format(self.width,
         """Get the stored colour value."""
         try:
             return self.valid_colors[self.color]
+        except KeyError:
+            return None
+
+    def get_variant(self):
+        try:
+            return DISPLAY_VARIANT[self.display_variant]
         except KeyError:
             return None
 

--- a/library/inky/eeprom.py
+++ b/library/inky/eeprom.py
@@ -97,20 +97,20 @@ Time: {}""".format(self.width,
         """Set the stored colour value."""
         try:
             self.color = self.valid_colors.index(color)
-        except KeyError:
+        except IndexError:
             raise ValueError('Invalid colour: {}'.format(color))
 
     def get_color(self):
         """Get the stored colour value."""
         try:
             return self.valid_colors[self.color]
-        except KeyError:
+        except IndexError:
             return None
 
     def get_variant(self):
         try:
             return DISPLAY_VARIANT[self.display_variant]
-        except KeyError:
+        except IndexError:
             return None
 
 


### PR DESCRIPTION
The examples were presenting an issue where - if the user, with good intentions, specified their board type as "X" and it was in fact "Y" - the display wouldn't update. This is particularly common with new-style Inky pHAT boards that require the SSD1608 driver. Short of reading the EEPROM the examples/driver cannot disambiguate between old-style pHAT and new-style pHAT and there's no obvious way for the user to tell, either.

This auto-detection stuff probably needs pushing into the library so it doesn't have to be copied near verbatim into each example.