### PR TITLE
Added Python3 shebang to buttons.py

### DIFF
--- a/examples/7color/buttons.py
+++ b/examples/7color/buttons.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import signal
 import RPi.GPIO as GPIO
 


### PR DESCRIPTION
Buttons.py in the `/examples/7color/` directory doesn't have a Python3 shebang, so it fails to run using the `./buttons.py` shortcut in Bash.  Added `#!/usr/bin/env python3` to the first line to fix this.