### PR TITLE
Add support for setting the border colour on an inky impression

### DIFF
--- a/examples/7color/cycle.py
+++ b/examples/7color/cycle.py
@@ -10,8 +10,9 @@ colors = ['Black', 'White', 'Green', 'Blue', 'Red', 'Yellow', 'Orange']
 
 for color in range(7):
     print("Color: {}".format(colors[color]))
-    for y in range(inky.height - 1):
-        for x in range(inky.width - 1):
+    for y in range(inky.height):
+        for x in range(inky.width):
             inky.set_pixel(x, y, color)
+    inky.set_border(color)
     inky.show()
     time.sleep(5.0)

--- a/library/inky/inky_uc8159.py
+++ b/library/inky/inky_uc8159.py
@@ -127,6 +127,7 @@ class Inky:
 
         self.resolution = resolution
         self.width, self.height = resolution
+        self.border_colour = WHITE
         self.cols, self.rows, self.rotation, self.offset_x, self.offset_y = _RESOLUTION[resolution]
 
         if colour not in ('multi'):
@@ -158,8 +159,6 @@ class Inky:
         #        # raise ValueError('Supplied width/height do not match Inky: {}x{}'.format(self.eeprom.width, self.eeprom.height))
 
         self.buf = numpy.zeros((self.rows, self.cols), dtype=numpy.uint8)
-
-        self.border_colour = 0
 
         self.dc_pin = dc_pin
         self.reset_pin = reset_pin
@@ -280,7 +279,8 @@ class Inky:
         # 0b11100000 = Vborder control (0b001 = LUTB voltage)
         # 0b00010000 = Data polarity
         # 0b00001111 = Vcom and data interval (0b0111 = 10, default)
-        self._send_command(UC8159_CDI, [0x37])  # 0b00110111
+        cdi = (self.border_colour << 5) | 0x17
+        self._send_command(UC8159_CDI, [cdi])  # 0b00110111
 
         # Gate/Source non-overlap period
         # 0b11110000 = Source to Gate (0b0010 = 12nS, default)
@@ -366,7 +366,8 @@ class Inky:
 
     def set_border(self, colour):
         """Set the border colour."""
-        raise NotImplementedError
+        if colour in (BLACK, WHITE, GREEN, BLUE, RED, YELLOW, ORANGE, CLEAN):
+            self.border_colour = colour
 
     def set_image(self, image, saturation=0.5):
         """Copy an image to the display.


### PR DESCRIPTION
Hi, I noticed the `inky_uc8159` (Inky Impression) implementation was lacking support for setting the border colour. 

This PR adds it (and also fixes an off by one error in the colour cycling demo)

I've tested this on my device, and it seems to work

-----

While we're talking, would you be able to provide me with a link to the picture used in this demo photo?:
![](https://cdn.shopify.com/s/files/1/0174/1800/products/inky-7-colour-on-white-resellers-1_1024x1024.jpg?v=1605026758)