### PR TITLE
Patch python2 invalid arg for xfer

### DIFF
--- a/library/inky/inky_uc8159.py
+++ b/library/inky/inky_uc8159.py
@@ -400,6 +400,10 @@ class Inky:
         """
         self._gpio.output(self.cs_pin, 0)
         self._gpio.output(self.dc_pin, dc)
+
+        if type(values) is str:
+            values = [ord(c) for c in values]
+
         try:
             self._spi_bus.xfer3(values)
         except AttributeError:


### PR DESCRIPTION
Can't hurt to fix this for the Python 2.x holdouts, but we (by which I mean, I) reeeaaaalllly should be pushing forward with Python 3.x-only support.