### PR TITLE
Enhance support for SSD1608

### DIFF
--- a/examples/name-badge.py
+++ b/examples/name-badge.py
@@ -42,6 +42,10 @@ if inky_display.resolution == (600, 448):
     scale_size = 2.20
     padding = 30
 
+if inky_display.resolution == (250, 122):
+    scale_size = 1.30
+    padding = -5
+
 # Create a new canvas to draw on
 
 img = Image.new("P", inky_display.resolution)

--- a/library/inky/inky_ssd1608.py
+++ b/library/inky/inky_ssd1608.py
@@ -191,6 +191,19 @@ class Inky:
         # Write LUT DATA
         self._send_command(ssd1608.WRITE_LUT, self._luts[self.lut])
 
+        if self.border_colour == self.BLACK:
+            self._send_command(ssd1608.WRITE_BORDER, 0b00000000)
+            # GS Transition + Waveform 00 + GSA 0 + GSB 0
+        elif self.border_colour == self.RED and self.colour == 'red':
+            self._send_command(ssd1608.WRITE_BORDER, 0b00000110)
+            # GS Transition + Waveform 01 + GSA 1 + GSB 0
+        elif self.border_colour == self.YELLOW and self.colour == 'yellow':
+            self._send_command(ssd1608.WRITE_BORDER, 0b00001111)
+            # GS Transition + Waveform 11 + GSA 1 + GSB 1
+        elif self.border_colour == self.WHITE:
+            self._send_command(ssd1608.WRITE_BORDER, 0b00000001)
+            # GS Transition + Waveform 00 + GSA 0 + GSB 1
+
         # Set RAM address to 0, 0
         self._send_command(ssd1608.SET_RAMXCOUNT, [0x00])
         self._send_command(ssd1608.SET_RAMYCOUNT, [0x00, 0x00])


### PR DESCRIPTION
I finally got my sticky fingers on a red SSD1608 Inky pHAT and after a little trial and error, I have all four border colours working correctly on my red and yellow SSD1608 Inkys.

Not able to test on a black/white part.

![IMG-3088](https://user-images.githubusercontent.com/28573604/113342946-0877ab00-9327-11eb-9b00-5192aed5e304.jpg)

Also, added appropriate scaling for one of the examples on the higher res SSD1608 display. 

Before
![image](https://user-images.githubusercontent.com/28573604/113347619-58597080-932d-11eb-9162-9ef35e17ce29.jpeg)

After
![image](https://user-images.githubusercontent.com/28573604/113347644-5f807e80-932d-11eb-91d3-212b820ea9d1.jpeg)