### PR TITLE
Update inky_uc8159.py

### DIFF
--- a/library/inky/inky_uc8159.py
+++ b/library/inky/inky_uc8159.py
@@ -300,7 +300,7 @@ class Inky:
             UC8159_PFS, [0x00]  # PFS_1_FRAME
         )
 
-    def _busy_wait(self, timeout=15.0):
+    def _busy_wait(self, timeout=30.0):
         """Wait for busy/wait pin."""
         t_start = time.time()
         while not self._gpio.input(self.busy_pin):


### PR DESCRIPTION
Increase the default timeout, since 15 seconds doesn't seem to be enough for the 7color display.
Fixes issue #103