### PR TITLE
Fix set_image reshape for #93

### DIFF
--- a/library/inky/inky_uc8159.py
+++ b/library/inky/inky_uc8159.py
@@ -389,7 +389,7 @@ class Inky:
             # Force source image data to be loaded for `.im` to work
             image.load()
             image = image.im.convert("P", True, palette_image.im)
-        self.buf = numpy.array(image, dtype=numpy.uint8).reshape((self.cols, self.rows))
+        self.buf = numpy.array(image, dtype=numpy.uint8).reshape((self.rows, self.cols))
 
     def _spi_write(self, dc, values):
         """Write values over SPI.


### PR DESCRIPTION
As reported in https://github.com/pimoroni/inky/issues/93 - using `set_image` was resulting in a buffer that didn't match the shape of the display. This would work fine when shaped into a 1d array for writing over SPI, but would break all future attempts to `set_pixel` since it turned the buffer from `600x448` into `448x600`.