### PR TITLE
Move fonts to example-depends

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -21,10 +21,10 @@ Python library for the [Inky pHAT](https://shop.pimoroni.com/products/inky-phat)
 The Python pip package is named inky, on the Raspberry Pi install with:
 
 ```
-pip3 install inky[rpi,fonts]
+pip3 install inky[rpi,example-depends]
 ```
 
-This will install Inky along with dependencies for the Raspberry Pi, plus fonts used by the examples.
+This will install Inky along with dependencies for the Raspberry Pi, plus modules used by the examples.
 
 If you want to simulate Inky on your desktop, use:
 

--- a/library/setup.py
+++ b/library/setup.py
@@ -56,7 +56,6 @@ setup(
     extras_require={
         'rpi-gpio-output': ['RPi.GPIO'],
         'rpi': ['RPi.GPIO'],
-        'fonts': ['font-fredoka-one', 'font-source-serif-pro', 'font-hanken-grotesk', 'font-intuitive'],
-        'example-depends': ['requests', 'geocoder', 'beautifulsoup4']
+        'example-depends': ['requests', 'geocoder', 'beautifulsoup4', 'font-fredoka-one', 'font-source-serif-pro', 'font-hanken-grotesk', 'font-intuitive']
     }
 )


### PR DESCRIPTION
They're only needed for the example scripts, and it doesn't make much sense to install them without the rest of their dependencies.