### PR TITLE
Use built-in mock library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.7, 3.8]
+        python: [3.5, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/library/tests/conftest.py
+++ b/library/tests/conftest.py
@@ -5,7 +5,7 @@ that might otherwise have runtime side-effects.
 
 """
 import sys
-import mock
+from unittest import mock
 import pytest
 
 from tools import MockSMBus

--- a/library/tests/test_init.py
+++ b/library/tests/test_init.py
@@ -1,6 +1,6 @@
 """Initialization tests for Inky."""
 
-import mock
+from unittest import mock
 import pytest
 
 

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -3,7 +3,7 @@
 import sys
 import site
 
-import mock
+from unittest import mock
 PACKAGE_NAME = u"Inky"
 PACKAGE_HANDLE = "Inky"
 PACKAGE_MODULE = "inky"

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -13,7 +13,7 @@ PACKAGE_MODULE = "inky"
 
 import sphinx_rtd_theme
 
-MOCK_MODULES = ['RPi', 'RPi.GPIO', 'smbus2', 'smbus', 'numpy', 'spidev']
+MOCK_MODULES = ['RPi', 'RPi.GPIO', 'smbus2', 'smbus', 'numpy', 'spidev', 'PIL']
 for module_name in MOCK_MODULES:
     sys.modules[module_name] = mock.MagicMock()
 

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -9,7 +9,6 @@ idna==3.2
 imagesize==1.2.0
 Jinja2==3.0.1
 MarkupSafe==2.0.1
-mock==4.0.3
 packaging==21.0
 Pillow==8.3.1
 Pygments==2.9.0


### PR DESCRIPTION
Python 3 incorporated the third-party "mock" library under the "unittest" namespace back around 3.1 (I think? A while ago anyway :). This just removes the dependency and tweaks `doc/conf.py` to use the built-in one.