### PR TITLE
UC8159 Update WIDTH and HEIGHT.

### DIFF
--- a/library/inky/inky_uc8159.py
+++ b/library/inky/inky_uc8159.py
@@ -141,6 +141,7 @@ class Inky:
 
         self.resolution = resolution
         self.width, self.height = resolution
+        self.WIDTH, self.HEIGHT = resolution
         self.border_colour = WHITE
         self.cols, self.rows, self.rotation, self.offset_x, self.offset_y, self.resolution_setting = _RESOLUTION[resolution]
 


### PR DESCRIPTION
Set the uppercase WIDTH and HEIGHT for the UC8159 eeprom. These are set by default in the `__init__` function but are never overridden for a different dimension impression. 