### PR TITLE
Add palettes to `InkyMockImpression` class

### DIFF
--- a/library/inky/mock.py
+++ b/library/inky/mock.py
@@ -216,6 +216,26 @@ class InkyMockImpression(InkyMock):
     WIDTH = 600
     HEIGHT = 448
 
+    DESATURATED_PALETTE = [
+        [0, 0, 0],
+        [255, 255, 255],
+        [0, 255, 0],
+        [0, 0, 255],
+        [255, 0, 0],
+        [255, 255, 0],
+        [255, 140, 0],
+        [255, 255, 255]]
+
+    SATURATED_PALETTE = [
+        [57, 48, 57],
+        [255, 255, 255],
+        [58, 91, 70],
+        [61, 59, 94],
+        [156, 72, 75],
+        [208, 190, 71],
+        [177, 106, 73],
+        [255, 255, 255]]
+
     def __init__(self):
         """Initialize a new mock Inky Impression."""
         InkyMock.__init__(self, 'multi')


### PR DESCRIPTION
This adds `SATURATED_PALETTE` and `DESATURATED_PALETTE` to the `InkyMockImpression` class, which is required for the `_palette_blend` call in `set_image()` to work.

Fixes #166.