### PR TITLE
Add `resolution` parameter to `InkyMockImpression.__init__`

### DIFF
--- a/library/inky/mock.py
+++ b/library/inky/mock.py
@@ -218,9 +218,9 @@ class InkyMockImpression(InkyMock):
 
     def __init__(self, resolution=None):
         """Initialize a new mock Inky Impression.
-        
+
         :param resolution: (width, height) in pixels, default: (600, 448)
-        
+
         """
         if resolution is not None:
             self.WIDTH, self.HEIGHT = resolution

--- a/library/inky/mock.py
+++ b/library/inky/mock.py
@@ -216,8 +216,14 @@ class InkyMockImpression(InkyMock):
     WIDTH = 600
     HEIGHT = 448
 
-    def __init__(self):
-        """Initialize a new mock Inky Impression."""
+    def __init__(self, resolution=None):
+        """Initialize a new mock Inky Impression.
+        
+        :param resolution: (width, height) in pixels, default: (600, 448)
+        
+        """
+        if resolution is not None:
+            self.WIDTH, self.HEIGHT = resolution
         InkyMock.__init__(self, 'multi')
 
     def _simulate(self, region):


### PR DESCRIPTION
This permits simpler setting of the size of the Inky Impression being mocked.

For example, this allows:
``` python
display = InkyMockImpression((800, 480))
```
which will ensure that the buffer size gets set up correctly.

Fixes #168.