### PR TITLE
Fix parse error in dither-image-what.py

### DIFF
--- a/examples/what/dither-image-what.py
+++ b/examples/what/dither-image-what.py
@@ -18,7 +18,7 @@ inky_display.set_border(inky_display.WHITE)
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--image', '-i', type=str, required=True, help="Input image to be converted/displayed")
-args = parser.parse_args()
+args, _ = parser.parse_known_args()
 
 img_file = args.image
 


### PR DESCRIPTION
`parse_args` would fail since it didn't recognise type/colour. Only parse args it knows about and ignore the rest.