### PR TITLE
Fix issue 175 by replacing deprecated getsize function

### DIFF
--- a/examples/name-badge.py
+++ b/examples/name-badge.py
@@ -7,6 +7,9 @@ from font_hanken_grotesk import HankenGroteskBold, HankenGroteskMedium
 from font_intuitive import Intuitive
 from inky.auto import auto
 
+def getsize(font, text):
+    _, _, right, bottom = font.getbbox(text)
+    return (right, bottom)
 
 print("""Inky pHAT/wHAT: Hello... my name is:
 
@@ -82,21 +85,21 @@ for y in range(y_bottom, inky_display.height):
 
 # Calculate the positioning and draw the "Hello" text
 
-hello_w, hello_h = hanken_bold_font.getsize("Hello")
+hello_w, hello_h = getsize(hanken_bold_font, "Hello")
 hello_x = int((inky_display.width - hello_w) / 2)
 hello_y = 0 + padding
 draw.text((hello_x, hello_y), "Hello", inky_display.WHITE, font=hanken_bold_font)
 
 # Calculate the positioning and draw the "my name is" text
 
-mynameis_w, mynameis_h = hanken_medium_font.getsize("my name is")
+mynameis_w, mynameis_h = getsize(hanken_medium_font, "my name is")
 mynameis_x = int((inky_display.width - mynameis_w) / 2)
 mynameis_y = hello_h + padding
 draw.text((mynameis_x, mynameis_y), "my name is", inky_display.WHITE, font=hanken_medium_font)
 
 # Calculate the positioning and draw the name text
 
-name_w, name_h = intuitive_font.getsize(name)
+name_w, name_h = getsize(intuitive_font, name)
 name_x = int((inky_display.width - name_w) / 2)
 name_y = int(y_top + ((y_bottom - y_top - name_h) / 2))
 draw.text((name_x, name_y), name, inky_display.BLACK, font=intuitive_font)

--- a/examples/what/quotes-what.py
+++ b/examples/what/quotes-what.py
@@ -32,11 +32,13 @@ inky_display = auto(ask_user=True, verbose=True)
 inky_display.set_border(inky_display.WHITE)
 # inky_display.set_rotation(180)
 
+def getsize(font, text):
+    _, _, right, bottom = font.getbbox(text)
+    return (right, bottom)
+
 # This function will take a quote as a string, a width to fit
 # it into, and a font (one that's been loaded) and then reflow
 # that quote with newlines to fit into the space required.
-
-
 def reflow_quote(quote, width, font):
     words = quote.split(" ")
     reflowed = '"'
@@ -44,7 +46,7 @@ def reflow_quote(quote, width, font):
 
     for i in range(len(words)):
         word = words[i] + " "
-        word_length = font.getsize(word)[0]
+        word_length = getsize(font, word)[0]
         line_length += word_length
 
         if line_length < width:
@@ -105,7 +107,7 @@ people = [
 
 padding = 50
 max_width = WIDTH - padding
-max_height = HEIGHT - padding - author_font.getsize("ABCD ")[1]
+max_height = HEIGHT - padding - getsize(author_font, "ABCD ")[1]
 
 below_max_length = False
 
@@ -117,7 +119,7 @@ while not below_max_length:
     quote = wikiquotes.random_quote(person, "english")
 
     reflowed = reflow_quote(quote, max_width, quote_font)
-    p_w, p_h = quote_font.getsize(reflowed)  # Width and height of quote
+    p_w, p_h = getsize(quote_font, reflowed)  # Width and height of quote
     p_h = p_h * (reflowed.count("\n") + 1)   # Multiply through by number of lines
 
     if p_h < max_height:
@@ -129,7 +131,7 @@ while not below_max_length:
 # x- and y-coordinates for the top left of the quote
 
 quote_x = (WIDTH - max_width) / 2
-quote_y = ((HEIGHT - max_height) + (max_height - p_h - author_font.getsize("ABCD ")[1])) / 2
+quote_y = ((HEIGHT - max_height) + (max_height - p_h - getsize(author_font, "ABCD ")[1])) / 2
 
 # x- and y-coordinates for the top left of the author
 
@@ -151,7 +153,7 @@ draw.rectangle(
 draw.rectangle(
     (
         padding / 4,
-        author_y + author_font.getsize("ABCD ")[1] + (padding / 4) + 5,
+        author_y + getsize(author_font, "ABCD ")[1] + (padding / 4) + 5,
         WIDTH - (padding / 4),
         HEIGHT - (padding / 4)
     ), fill=inky_display.RED)


### PR DESCRIPTION
Fix #175 

`font.getsize` can be replaced with a simple function calling through to `font.getbbox`. This seems to give very similar results, testing with a few quotes the size was almost always identical, sometimes different by 1 pixel.

This allows the updated examples to work with Pillow 10.x