### PR TITLE
Add tests for set_image.

### DIFF
--- a/inky/inky.py
+++ b/inky/inky.py
@@ -391,10 +391,7 @@ class Inky:
             image.load()
             image = image.im.convert("P", True, palette_image.im)
 
-        canvas = Image.new("P", (self.rows, self.cols))
-        width, height = image.size
-        canvas.paste(image, (0, 0, width, height))
-        self.buf = numpy.array(canvas, dtype=numpy.uint8).reshape((self.cols, self.rows))
+        self.buf = numpy.array(image, dtype=numpy.uint8).reshape((self.cols, self.rows))
 
     def _spi_write(self, dc, values):
         """Write values over SPI.

--- a/tests/test_set_image.py
+++ b/tests/test_set_image.py
@@ -1,0 +1,28 @@
+"""Set image tests for Inky."""
+import pytest
+
+
+@pytest.mark.parametrize('resolution', [(800, 480), (600, 448), (400, 300), (212, 104), (250, 122)])
+def test_inky_set_image(GPIO, spidev, smbus2, resolution):
+    from PIL import Image
+
+    from inky.inky import Inky
+
+    phat = Inky(resolution)
+
+    width, height = phat.resolution
+
+    image = Image.new("P", (width, height))
+
+    for x in range(width):
+        image.putpixel((x, 0), x % 3)
+
+    assert image.size == (width, height)
+
+    phat.set_image(image)
+    phat.set_pixel(0, 0, 2)
+
+    data = [x % 3 for x in range(width)]
+    data[0] = 2
+
+    assert phat.buf.flatten().tolist()[0:width] == data


### PR DESCRIPTION
This change attempts to test for the Inky wHAT `set_image` display issue mentioned in #182 and tries to determine if the internal buffer is set correctly.

# Testing

If you want to test this branch, make sure you're running in the virtual environment to which you installed Inky and run:

```
pip install git+https://github.com/pimoroni/inky@patch-inky-resolution-test --force-reinstall
```

That should replace your version of the Inky library with the experimental version on this branch!