### PR TITLE
fix: html.sh call to image.py is missing the --file flag

### DIFF
--- a/examples/7color/html/html.sh
+++ b/examples/7color/html/html.sh
@@ -4,4 +4,4 @@ CWD=`pwd`
 filename=$1
 
 firefox --headless --screenshot --window-size=600,448 file://$CWD/$filename
-../image.py screenshot.png
+../image.py --file screenshot.png


### PR DESCRIPTION
The 7color html example calls `image.py` without the required `--file` flag.