### PR TITLE
CI: Rewrite set_image for Spectra 6 to handle more edge cases

### DIFF
--- a/inky/inky_e673.py
+++ b/inky/inky_e673.py
@@ -79,8 +79,8 @@ class Inky:
     WHITE = 1
     YELLOW = 2
     RED = 3
-    BLUE = 5
-    GREEN = 6
+    BLUE = 4
+    GREEN = 5
 
     WIDTH = 0
     HEIGHT = 0

--- a/inky/inky_e673.py
+++ b/inky/inky_e673.py
@@ -317,6 +317,7 @@ class Inky:
         if image.mode == "P":
             # Create a pure colour palette from DESATURATED_PALETTE
             palette = numpy.array(DESATURATED_PALETTE, dtype=numpy.uint8).flatten().tobytes()
+            palette_image.putpalette(palette)
 
             # Assume that palette mode images with an unset palette use the
             # default colour order and "DESATURATED_PALETTE" pure colours
@@ -327,7 +328,6 @@ class Inky:
             # all the correct colours, but not exactly in the right order.
             if len(image.palette.colors) == 6:
                 dither = Image.Dither.NONE
-                palette_image.putpalette(palette)
         else:
             # All other image should be quantized and dithered
             palette = self._palette_blend(saturation)

--- a/inky/inky_e673.py
+++ b/inky/inky_e673.py
@@ -309,19 +309,33 @@ class Inky:
         if not image.size == (self.width, self.height):
             raise ValueError(f"Image must be ({self.width}x{self.height}) pixels!")
 
-        palette = self._palette_blend(saturation)
+        dither = Image.Dither.FLOYDSTEINBERG
+
         # Image size doesn't matter since it's just the palette we're using
         palette_image = Image.new("P", (1, 1))
-        # Set our 6 colour palette
-        palette_image.putpalette(palette)
 
-        # Assume that palette mode images with an unset palette use the
-        # default colour order and "DESATURATED_PALETTE" pure colours
-        if image.mode == "P" and not image.palette.colors:
-            image.putpalette(numpy.array(DESATURATED_PALETTE, dtype=numpy.uint8).flatten().tobytes())
+        if image.mode == "P":
+            # Create a pure colour palette from DESATURATED_PALETTE
+            palette = numpy.array(DESATURATED_PALETTE, dtype=numpy.uint8).flatten().tobytes()
 
-        image = image.convert("RGB").quantize(6, palette=palette_image)
+            # Assume that palette mode images with an unset palette use the
+            # default colour order and "DESATURATED_PALETTE" pure colours
+            if not image.palette.colors:
+                image.putpalette(palette)
 
+            # Assume that palette mode images with exactly six colours use
+            # all the correct colours, but not exactly in the right order.
+            if len(image.palette.colors) == 6:
+                dither = Image.Dither.NONE
+                palette_image.putpalette(palette)
+        else:
+            # All other image should be quantized and dithered
+            palette = self._palette_blend(saturation)
+            palette_image.putpalette(palette)
+
+        image = image.convert("RGB").quantize(6, palette=palette_image, dither=dither)
+
+        # Remap our sequential palette colours to display native (missing colour 4)
         remap = numpy.array([0, 1, 2, 3, 5, 6])
         self.buf = remap[numpy.array(image, dtype=numpy.uint8).reshape((self.rows, self.cols))]
 

--- a/inky/inky_el133uf1.py
+++ b/inky/inky_el133uf1.py
@@ -97,8 +97,8 @@ class Inky:
     WHITE = 1
     YELLOW = 2
     RED = 3
-    BLUE = 5
-    GREEN = 6
+    BLUE = 4
+    GREEN = 5
 
     WIDTH = 0
     HEIGHT = 0

--- a/inky/inky_el133uf1.py
+++ b/inky/inky_el133uf1.py
@@ -342,6 +342,7 @@ class Inky:
         if image.mode == "P":
             # Create a pure colour palette from DESATURATED_PALETTE
             palette = numpy.array(DESATURATED_PALETTE, dtype=numpy.uint8).flatten().tobytes()
+            palette_image.putpalette(palette)
 
             # Assume that palette mode images with an unset palette use the
             # default colour order and "DESATURATED_PALETTE" pure colours
@@ -352,7 +353,6 @@ class Inky:
             # all the correct colours, but not exactly in the right order.
             if len(image.palette.colors) == 6:
                 dither = Image.Dither.NONE
-                palette_image.putpalette(palette)
         else:
             # All other image should be quantized and dithered
             palette = self._palette_blend(saturation)

--- a/inky/inky_el133uf1.py
+++ b/inky/inky_el133uf1.py
@@ -332,15 +332,18 @@ class Inky:
         if not image.size == (self.width, self.height):
             raise ValueError(f"Image must be ({self.width}x{self.height}) pixels!")
 
-        if not image.mode == "P":
-            palette = self._palette_blend(saturation)
-            # Image size doesn't matter since it's just the palette we're using
-            palette_image = Image.new("P", (1, 1))
-            # Set our 7 colour palette (+ clear) and zero out the remaining colours
-            palette_image.putpalette(palette + [0, 0, 0] * 250)
-            # Force source image data to be loaded for `.im` to work
-            image.load()
-            image = image.im.convert("P", True, palette_image.im)
+        palette = self._palette_blend(saturation)
+        # Image size doesn't matter since it's just the palette we're using
+        palette_image = Image.new("P", (1, 1))
+        # Set our 6 colour palette
+        palette_image.putpalette(palette)
+
+        # Assume that palette mode images with an unset palette use the
+        # default colour order and "DESATURATED_PALETTE" pure colours
+        if image.mode == "P" and not image.palette.colors:
+            image.putpalette(numpy.array(DESATURATED_PALETTE, dtype=numpy.uint8).flatten().tobytes())
+
+        image = image.convert("RGB").quantize(6, palette=palette_image)
 
         remap = numpy.array([0, 1, 2, 3, 5, 6])
         self.buf = remap[numpy.array(image, dtype=numpy.uint8).reshape((self.rows, self.cols))]

--- a/tests/test_e673.py
+++ b/tests/test_e673.py
@@ -1,0 +1,13 @@
+def test_set_image_p256(GPIO, spidev):
+    from PIL import Image
+
+    from inky import inky_e673
+
+    img = Image.new("P", (800, 480))
+
+    for x in range(256):
+        img.putpixel((x, x), (x, 0, 0))
+
+    inky = inky_e673.Inky()
+
+    inky.set_image(img)


### PR DESCRIPTION
We've had various problems with the image remapping code (particularly where P mode images have more than six colours), most of which was very, very old code I wrote back when I had much less idea what I was doing.

This rewrite should fix all cases by avoiding as much special casing as possible. The one exception is where a P mode image has no palette at all, and thus no colour information. For example the Hello World example uses palette indexes but never creates a palette (`image.palette.colors == {}`) so attempting to quantize it has very bizarre results.

1. [x] Test for https://github.com/pimoroni/inky/issues/227
2. [x] Test https://github.com/pimoroni/inky/pull/221 fixes this case (it does not)
3. [x] Test https://github.com/pimoroni/inky/pull/221 looks good! (N/A)
4. [x] New goal: Rewrite set_image