### PR TITLE
Enable I2C as post install step.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,5 +128,6 @@ configtxt = [
     "dtoverlay=spi0-0cs"
 ]
 commands = [
+    "sudo raspi-config nonint do_i2c 0",
     "sudo raspi-config nonint do_spi 0"
 ]


### PR DESCRIPTION
Previously this only enabled SPI causing issues with auto detecting the connected board ("Failed to detect an Inky board."), now it enables I2C as well.

See: https://github.com/RPi-Distro/raspi-config/blob/master/raspi-config#L973-L975 for config parameters, essentially setting it to 0 enables I2C.