### PR TITLE
Replace 'time.time()' with 'time.monotonic()' for timeout loops

### DIFF
--- a/inky/inky_e673.py
+++ b/inky/inky_e673.py
@@ -233,10 +233,10 @@ class Inky:
             time.sleep(timeout)
             return
 
-        t_start = time.time()
+        t_start = time.monotonic()
         while not self._gpio.get_value(self.busy_pin) == Value.ACTIVE:
             time.sleep(0.1)
-            if time.time() - t_start > timeout:
+            if time.monotonic() - t_start > timeout:
                 warnings.warn(f"Busy Wait: Timed out after {timeout:0.2f}s")
                 return
 

--- a/inky/inky_el133uf1.py
+++ b/inky/inky_el133uf1.py
@@ -262,10 +262,10 @@ class Inky:
             time.sleep(timeout)
             return
 
-        t_start = time.time()
+        t_start = time.monotonic()
         while self._gpio.get_value(self.busy_pin) == Value.ACTIVE:
             time.sleep(0.1)
-            if time.time() - t_start > timeout:
+            if time.monotonic() - t_start > timeout:
                 warnings.warn(f"Busy Wait: Timed out after {timeout:0.2f}s")
                 return
 

--- a/inky/inky_jd79661.py
+++ b/inky/inky_jd79661.py
@@ -216,10 +216,10 @@ class Inky:
             time.sleep(timeout)
             return
 
-        t_start = time.time()
+        t_start = time.monotonic()
         while not self._gpio.get_value(self.busy_pin) == Value.ACTIVE:
             time.sleep(0.1)
-            if time.time() - t_start > timeout:
+            if time.monotonic() - t_start > timeout:
                 warnings.warn(f"Busy Wait: Timed out after {timeout:0.2f}s")
                 return
 

--- a/inky/inky_jd79668.py
+++ b/inky/inky_jd79668.py
@@ -212,10 +212,10 @@ class Inky:
             time.sleep(timeout)
             return
 
-        t_start = time.time()
+        t_start = time.monotonic()
         while not self._gpio.get_value(self.busy_pin) == Value.ACTIVE:
             time.sleep(0.1)
-            if time.time() - t_start > timeout:
+            if time.monotonic() - t_start > timeout:
                 warnings.warn(f"Busy Wait: Timed out after {timeout:0.2f}s")
                 return
 


### PR DESCRIPTION
'time.time()' uses the system clock, which can jump forwards and backwards, e.g. because the device syncs with a time server. 'time.monotonic()' is stable and will not jump.

My specific problem is that I have a picture frame which powers on every so often, fetches another image to display, shows it, and powers off again. It doesn't keep time when powered off (so powers on with the clock in the past), then it syncs with an NTP server at some point shortly after power-on, and the clock jumps forwards. However, this often happens inside the busy polling loop, which means that the loop exits straight away with a timeout. This means that we don't want for the image to be fully displayed before returning.